### PR TITLE
Update daemonset.yaml

### DIFF
--- a/ofed-driver/chart/templates/daemonset.yaml
+++ b/ofed-driver/chart/templates/daemonset.yaml
@@ -69,11 +69,11 @@ spec:
               level: "s0"
           env:
             - name: UNLOAD_STORAGE_MODULES
-              value: {{ .Values.config.unload_host_storage_modules }}
+              value: {{ .Values.config.unload_host_storage_modules | quote }}
             - name: ENABLE_NFSRDMA
-              value: {{ .Values.config.enable_nfsrdma }}
+              value: {{ .Values.config.enable_nfsrdma | quote }}
             - name: RESTORE_DRIVER_ON_POD_TERMINATION
-              value: {{ .Values.config.restore_hostdriver_on_termination }}
+              value: {{ .Values.config.restore_hostdriver_on_termination | quote }}
             {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}


### PR DESCRIPTION
fix

```
Error: INSTALLATION FAILED: DaemonSet in version "v1" cannot be handled as a DaemonSet: json: cannot unmarshal bool into Go struct field EnvVar.spec.template.spec.containers.env.value of type string
helm.go:84: [debug] DaemonSet in version "v1" cannot be handled as a DaemonSet: json: cannot unmarshal bool into Go struct field EnvVar.spec.template.spec.containers.env.value of type string
```