### PR TITLE
fix: '/.driver-ready' No such file or directory

### DIFF
--- a/ofed-driver/chart/Chart.yaml
+++ b/ofed-driver/chart/Chart.yaml
@@ -5,11 +5,11 @@ home: "https://spidernet-io.github.io/charts"
 # application or library
 type: application
 # no need to modify this version , CI will auto update it with /VERSION
-version: 24.04.0
+version: 24.04.1
 # This field is informational, and has no impact on chart version calculations .
 # Leaving it unquoted can lead to parsing issues in some cases
 # no need to modify this version , CI will auto update it with /VERSION
-appVersion: "24.04.0"
+appVersion: "24.04.1"
 kubeVersion: ">= 1.16.0-0"
 description: ofed driver
 sources:

--- a/ofed-driver/chart/templates/daemonset.yaml
+++ b/ofed-driver/chart/templates/daemonset.yaml
@@ -97,7 +97,7 @@ spec:
           startupProbe:
             exec:
               command:
-                [sh, -c, 'ls /.driver-ready']
+                [sh, -c, 'ls ./driver-ready']
             initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
             failureThreshold: 60
             successThreshold: 1


### PR DESCRIPTION
```
Events:
[508](https://github.com/ty-dc/charts/actions/runs/10699257267/job/29660403876#step:10:509)  Type     Reason     Age                    From               Message
[509](https://github.com/ty-dc/charts/actions/runs/10699257267/job/29660403876#step:10:510)  ----     ------     ----                   ----               -------
[510](https://github.com/ty-dc/charts/actions/runs/10699257267/job/29660403876#step:10:511)  Normal   Scheduled  10m                    default-scheduler  Successfully assigned ofed-driver/mofed-ubuntu-22.04-ds-4kfr5 to charts-control-plane
[511](https://github.com/ty-dc/charts/actions/runs/10699257267/job/29660403876#step:10:512)  Normal   Pulled     10m                    kubelet            Container image "[nvcr.io/nvidia/mellanox/doca-driver:24.04-0.6.6.0-0-ubuntu22.04-amd64](http://nvcr.io/nvidia/mellanox/doca-driver:24.04-0.6.6.0-0-ubuntu22.04-amd64)" already present on machine
[512](https://github.com/ty-dc/charts/actions/runs/10699257267/job/29660403876#step:10:513)  Normal   Created    10m                    kubelet            Created container mofed-container
[513](https://github.com/ty-dc/charts/actions/runs/10699257267/job/29660403876#step:10:514)  Normal   Started    9m59s                  kubelet            Started container mofed-container
[514](https://github.com/ty-dc/charts/actions/runs/10699257267/job/29660403876#step:10:515)  Warning  Unhealthy  119s (x23 over 9m20s)  kubelet            Startup probe failed: ls: cannot access '/.driver-ready': No such file or directory
```