### PR TITLE
CI: bump upload-artifact to v4.6.0

### DIFF
--- a/.github/workflows/callBuildImage.yaml
+++ b/.github/workflows/callBuildImage.yaml
@@ -172,7 +172,7 @@ jobs:
           echo "" >> image-digest/${{ env.image_name }}.txt
 
       - name: Upload artifact digests
-        uses: actions/upload-artifact@v3.1.3
+        uses: actions/upload-artifact@v4.6.0
         with:
           name: image-digest
           path: image-digest


### PR DESCRIPTION
Fixes https://github.com/spidernet-io/charts/actions/runs/13213355777/job/36889658284

```
Prepare all required actions
Getting action download info
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3.1.3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
```